### PR TITLE
Add code-style HTML editor for Drupal conversion

### DIFF
--- a/drupal converter.html
+++ b/drupal converter.html
@@ -8,7 +8,10 @@
 <body class="bg-gray-100 min-h-screen flex items-center justify-center p-6">
   <div class="bg-white shadow-xl rounded-2xl p-8 w-full max-w-3xl">
     <h1 class="text-2xl font-bold text-center text-indigo-600 mb-6">Conversion OVP vers Drupal</h1>
-    
+    <div class="text-right mb-4">
+      <a href="editor.html" class="text-sm text-indigo-600 underline">Mode éditeur</a>
+    </div>
+
     <!-- Zone de dépôt -->
     <div id="dropzone" 
          class="border-2 border-dashed border-gray-300 rounded-xl p-10 text-center cursor-pointer bg-gray-50 hover:bg-gray-100 transition">

--- a/editor.html
+++ b/editor.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Éditeur OVP vers Drupal</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/mode/xml/xml.min.js"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex items-center justify-center p-6">
+  <div class="bg-white shadow-xl rounded-2xl p-8 w-full max-w-4xl">
+    <div class="flex justify-between items-center mb-4">
+      <h1 class="text-2xl font-bold text-indigo-600">Éditeur OVP vers Drupal</h1>
+      <a href="drupal converter.html" class="text-sm text-indigo-600 underline">Mode simple</a>
+    </div>
+
+    <div class="mb-4">
+      <label for="fileInput" class="inline-block px-4 py-2 bg-indigo-600 text-white rounded-lg cursor-pointer hover:bg-indigo-700 transition">Choisir un fichier</label>
+      <input type="file" id="fileInput" accept=".html,.htm" class="hidden">
+    </div>
+
+    <textarea id="editor" class="w-full h-64 font-mono border rounded"></textarea>
+
+    <div class="mt-4">
+      <div class="flex justify-between items-center">
+        <h2 class="text-lg font-semibold text-gray-700">Code généré :</h2>
+        <button id="copyBtn" class="px-3 py-1 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition hidden">Copier le code</button>
+      </div>
+      <pre id="output" class="mt-3 bg-gray-900 text-green-200 p-4 rounded-lg overflow-x-auto text-sm hidden"></pre>
+    </div>
+  </div>
+
+  <script>
+    const fileInput = document.getElementById('fileInput');
+    const output = document.getElementById('output');
+    const copyBtn = document.getElementById('copyBtn');
+    const editor = CodeMirror.fromTextArea(document.getElementById('editor'), {
+      lineNumbers: true,
+      mode: 'xml'
+    });
+    editor.setSize(null, 400);
+
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        editor.setValue(e.target.result);
+        generateCode();
+      };
+      reader.readAsText(file);
+    });
+
+    editor.on('change', () => {
+      generateCode();
+    });
+
+    function generateCode() {
+      const htmlContent = editor.getValue();
+      if (!htmlContent.trim()) {
+        output.classList.add('hidden');
+        copyBtn.classList.add('hidden');
+        return;
+      }
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(htmlContent, 'text/html');
+      let result = '';
+
+      const mainTitle = doc.querySelector('input.title-input');
+      if (mainTitle && mainTitle.value) {
+        result += `<h2>${mainTitle.value.trim()}</h2>\n\n`;
+      }
+
+      const sections = doc.querySelectorAll('div.section-title, textarea');
+      sections.forEach(el => {
+        if (el.classList && el.classList.contains('section-title')) {
+          let title = el.textContent.replace(/\bi\b/g, '').trim();
+          title = title.replace(/\s+/g, ' ');
+          result += `<h3>${title}</h3>\n`;
+        } else if (el.tagName === 'TEXTAREA') {
+          let content = (el.value || el.textContent || '').trim();
+          content = content.replace(/<br\s*\/?>/gi, '\n');
+          content = content.replace(/\u00A0/g, ' ');
+          if (content.length > 0) {
+            result += `<p>${content}</p>\n\n`;
+          }
+        }
+      });
+
+      output.textContent = result.trim();
+      output.classList.remove('hidden');
+      copyBtn.classList.remove('hidden');
+    }
+
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(output.textContent).then(() => {
+        copyBtn.textContent = 'Copié ! ✅';
+        setTimeout(() => copyBtn.textContent = 'Copier le code', 1500);
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Link existing converter to a new editor page
- Allow HTML file import and editing with CodeMirror
- Auto-generate and copy updated Drupal-friendly code

## Testing
- `npm test` (fails: ENOENT no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b17c75d7708329b89d6831a6ec9070