### PR TITLE
Integrate code editor into main Drupal converter

### DIFF
--- a/drupal converter.html
+++ b/drupal converter.html
@@ -2,105 +2,109 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
-  <title>Conversion OVP vers Drupal</title>
+  <title>Éditeur OVP vers Drupal</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/mode/xml/xml.min.js"></script>
 </head>
 <body class="bg-gray-100 min-h-screen flex items-center justify-center p-6">
-  <div class="bg-white shadow-xl rounded-2xl p-8 w-full max-w-3xl">
-    <h1 class="text-2xl font-bold text-center text-indigo-600 mb-6">Conversion OVP vers Drupal</h1>
-    
-    <!-- Zone de dépôt -->
-    <div id="dropzone" 
-         class="border-2 border-dashed border-gray-300 rounded-xl p-10 text-center cursor-pointer bg-gray-50 hover:bg-gray-100 transition">
-      <p class="text-gray-600">Dépose ton fichier HTML ici ou</p>
-      <label for="fileInput" class="mt-2 inline-block px-4 py-2 bg-indigo-600 text-white rounded-lg cursor-pointer hover:bg-indigo-700 transition">
-        Choisir un fichier
-      </label>
+  <div class="bg-white shadow-xl rounded-2xl p-8 w-full max-w-4xl">
+    <h1 class="text-2xl font-bold text-center text-indigo-600 mb-4">Éditeur OVP vers Drupal</h1>
+    <div class="mb-4 text-center">
+      <label for="fileInput" class="inline-block px-4 py-2 bg-indigo-600 text-white rounded-lg cursor-pointer hover:bg-indigo-700 transition">Choisir un fichier</label>
       <input type="file" id="fileInput" accept=".html,.htm" class="hidden">
     </div>
+    <textarea id="editor" class="w-full h-64 font-mono border rounded"></textarea>
 
-    <!-- Résultat -->
-    <div class="mt-6">
+    <div class="mt-4">
       <div class="flex justify-between items-center">
         <h2 class="text-lg font-semibold text-gray-700">Code généré :</h2>
-        <button id="copyBtn" 
-                class="px-3 py-1 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition hidden">
-          Copier le code
-        </button>
+        <button id="copyBtn" class="px-3 py-1 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition hidden">Copier le code</button>
       </div>
       <pre id="output" class="mt-3 bg-gray-900 text-green-200 p-4 rounded-lg overflow-x-auto text-sm hidden"></pre>
     </div>
   </div>
 
   <script>
-    const dropzone = document.getElementById("dropzone");
-    const fileInput = document.getElementById("fileInput");
-    const output = document.getElementById("output");
-    const copyBtn = document.getElementById("copyBtn");
+    const fileInput = document.getElementById('fileInput');
+    const output = document.getElementById('output');
+    const copyBtn = document.getElementById('copyBtn');
+    const editor = CodeMirror.fromTextArea(document.getElementById('editor'), {
+      lineNumbers: true,
+      mode: 'xml'
+    });
+    editor.setSize(null, 400);
 
-    // Gestion drag & drop
-    dropzone.addEventListener("dragover", (e) => {
-      e.preventDefault();
-      dropzone.classList.add("bg-indigo-50", "border-indigo-400");
-    });
-    dropzone.addEventListener("dragleave", () => {
-      dropzone.classList.remove("bg-indigo-50", "border-indigo-400");
-    });
-    dropzone.addEventListener("drop", (e) => {
-      e.preventDefault();
-      dropzone.classList.remove("bg-indigo-50", "border-indigo-400");
-      handleFile(e.dataTransfer.files[0]);
-    });
-
-    fileInput.addEventListener("change", () => {
-      handleFile(fileInput.files[0]);
-    });
-
-    function handleFile(file) {
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files[0];
       if (!file) return;
       const reader = new FileReader();
-      reader.onload = function(e) {
-        const htmlContent = e.target.result;
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(htmlContent, "text/html");
-        let result = "";
-
-        // Récupérer le titre principal (input.title-input → h2)
-        const mainTitle = doc.querySelector("input.title-input");
-        if (mainTitle && mainTitle.value) {
-          result += `<h2>${mainTitle.value.trim()}</h2>\n\n`;
-        }
-
-        // Parcours des sections
-        const sections = doc.querySelectorAll("div.section-title, textarea");
-        sections.forEach(el => {
-          if (el.classList && el.classList.contains("section-title")) {
-            let title = el.textContent.replace(/\bi\b/g, "").trim();
-            title = title.replace(/\s+/g, " "); // supprime espaces multiples
-            result += `<h3>${title}</h3>\n`;
-          } else if (el.tagName === "TEXTAREA") {
-            let content = (el.value || el.textContent || "").trim();
-            content = content.replace(/<br\s*\/?>/gi, "\n");
-            content = content.replace(/\u00A0/g, " "); // supprime &nbsp;
-
-            if (content.length > 0) { // ✅ ignore les <p> vides
-              result += `<p>${content}</p>\n\n`;
-            }
-          }
-        });
-
-        output.textContent = result.trim();
-        output.classList.remove("hidden");
-        copyBtn.classList.remove("hidden");
+      reader.onload = (e) => {
+        editor.setValue(e.target.result);
+        generateCode();
       };
       reader.readAsText(file);
+    });
+
+    document.addEventListener('dragover', (e) => e.preventDefault());
+    document.addEventListener('drop', (e) => {
+      e.preventDefault();
+      const file = e.dataTransfer.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (ev) => {
+        editor.setValue(ev.target.result);
+        generateCode();
+      };
+      reader.readAsText(file);
+    });
+
+    editor.on('change', () => {
+      generateCode();
+    });
+
+    function generateCode() {
+      const htmlContent = editor.getValue();
+      if (!htmlContent.trim()) {
+        output.classList.add('hidden');
+        copyBtn.classList.add('hidden');
+        return;
+      }
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(htmlContent, 'text/html');
+      let result = '';
+
+      const mainTitle = doc.querySelector('input.title-input');
+      if (mainTitle && mainTitle.value) {
+        result += `<h2>${mainTitle.value.trim()}</h2>\n\n`;
+      }
+
+      const sections = doc.querySelectorAll('div.section-title, textarea');
+      sections.forEach(el => {
+        if (el.classList && el.classList.contains('section-title')) {
+          let title = el.textContent.replace(/\bi\b/g, '').trim();
+          title = title.replace(/\s+/g, ' ');
+          result += `<h3>${title}</h3>\n`;
+        } else if (el.tagName === 'TEXTAREA') {
+          let content = (el.value || el.textContent || '').trim();
+          content = content.replace(/<br\s*\/?>/gi, '\n');
+          content = content.replace(/\u00A0/g, ' ');
+          if (content.length > 0) {
+            result += `<p>${content}</p>\n\n`;
+          }
+        }
+      });
+
+      output.textContent = result.trim();
+      output.classList.remove('hidden');
+      copyBtn.classList.remove('hidden');
     }
 
-    // Copier dans presse-papier
-    copyBtn.addEventListener("click", () => {
+    copyBtn.addEventListener('click', () => {
       navigator.clipboard.writeText(output.textContent).then(() => {
-        copyBtn.textContent = "Copié ! ✅";
-        setTimeout(() => copyBtn.textContent = "Copier le code", 1500);
+        copyBtn.textContent = 'Copié ! ✅';
+        setTimeout(() => copyBtn.textContent = 'Copier le code', 1500);
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- Merge the CodeMirror editing interface into the main converter page
- Allow importing HTML files via dialog or drag-and-drop and editing directly
- Automatically regenerate and copy Drupal-friendly HTML from edited content

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b17c75d7708329b89d6831a6ec9070